### PR TITLE
Destructuring policy should not process enumerables

### DIFF
--- a/src/Masking.Serilog/ByMasking/DestructureByMaskingPolicy.cs
+++ b/src/Masking.Serilog/ByMasking/DestructureByMaskingPolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -33,7 +34,7 @@ namespace Masking.Serilog.ByMasking
 
         public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
         {
-            if (value == null)
+            if (value == null || value is IEnumerable)
             {
                 result = null;
                 return false;


### PR DESCRIPTION
There is a problem with destructuring IEnumerable instances.
The policy uses properties of IEnumerable instance instead of enumerating its elements.
So there is a fallback for the default scenarios.