### PR TITLE
Added support for C# 9.0 Records

### DIFF
--- a/src/Masking.Serilog/ByMasking/DestructureByMaskingPolicy.cs
+++ b/src/Masking.Serilog/ByMasking/DestructureByMaskingPolicy.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
@@ -63,7 +64,7 @@ namespace Masking.Serilog.ByMasking
         private static Properties GetProperties(Type type)
         {
             IEnumerable<PropertyInfo> typeProperties = type.GetRuntimeProperties()
-                .Where(p => p.CanRead);
+                .Where(p => p.CanRead && (p.Name != "EqualityContract" || !p.GetMethod.CustomAttributes.Any(a => a.AttributeType == typeof(CompilerGeneratedAttribute))));
             
             var entry = new Properties(typeProperties.ToArray(), new PropertyInfo[]{});
 
@@ -83,7 +84,7 @@ namespace Masking.Serilog.ByMasking
             }
 
             IEnumerable<PropertyInfo> typeProperties = type.GetRuntimeProperties()
-                .Where(p => p.CanRead);
+                .Where(p => p.CanRead && (p.Name != "EqualityContract" || !p.GetMethod.CustomAttributes.Any(a => a.AttributeType == typeof(CompilerGeneratedAttribute))));
 
             if (maskingOptions.ExcludeStaticProperties)
             {

--- a/test/Masking.Serilog.Tests/DestructureByMaskingTests.cs
+++ b/test/Masking.Serilog.Tests/DestructureByMaskingTests.cs
@@ -276,5 +276,36 @@ namespace Masking.Serilog.Tests
             Assert.AreEqual("Password", props[nameof(DestructureMeButIgnored.Password)].LiteralValue());
             Assert.AreEqual(25673433, props[nameof(DestructureMeButIgnored.Secret)].LiteralValue());
         }
+
+        [Test]
+        public void RecordPropertyNamesAreMaskedWhenDestructuring()
+        {
+            LogEvent evt = null;
+
+            var log = new LoggerConfiguration()
+                .Destructure.ByMaskingProperties("password", "secret")
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            DestructureThisRecord.StaticProp = 1337;
+
+            var ignored = new DestructureThisRecord
+            {
+                Id = 2,
+                Name = "Name",
+                Password = "Password",
+                Secret = 25673433
+            };
+
+            log.Information("Here is {@Ignored}", ignored);
+
+            var props = GetPropsFromEvent("Ignored", evt);
+
+            Assert.AreEqual(2, props[nameof(DestructureThisRecord.Id)].LiteralValue());
+            Assert.AreEqual("Name", props[nameof(DestructureThisRecord.Name)].LiteralValue());
+            Assert.AreEqual("******", props[nameof(DestructureThisRecord.Password)].LiteralValue());
+            Assert.AreEqual("******", props[nameof(DestructureThisRecord.Secret)].LiteralValue());
+            Assert.AreEqual(1337, props[nameof(DestructureThisRecord.StaticProp)].LiteralValue());
+        }
     }
 }

--- a/test/Masking.Serilog.Tests/Masking.Serilog.Tests.csproj
+++ b/test/Masking.Serilog.Tests/Masking.Serilog.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Masking.Serilog.Tests</RootNamespace>
     <AssemblyName>Masking.Serilog.Tests</AssemblyName>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Masking.Serilog.Tests/Support/Models/DestructureThisRecord.cs
+++ b/test/Masking.Serilog.Tests/Support/Models/DestructureThisRecord.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Masking.Serilog.Tests.Support.Models
+{
+    public record DestructureThisRecord
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Password { get; set; }
+        public int Secret { get; set; }
+        public static int StaticProp { get; set; }
+    }
+}


### PR DESCRIPTION
This PR fixes infinite loop caused by the compiler generated `EqualityContract` property. Resolves https://github.com/evjenio/masking.serilog/issues/5.
